### PR TITLE
Update README for Joke Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,19 @@
-# Visual Studio Code - Open Source ("Code - OSS")
+# Joke Studio - Open Source ("Joke - OSS")
 
-[![Feature Requests](https://img.shields.io/github/issues/microsoft/vscode/feature-request.svg)](https://github.com/microsoft/vscode/issues?q=is%3Aopen+is%3Aissue+label%3Afeature-request+sort%3Areactions-%2B1-desc)
-[![Bugs](https://img.shields.io/github/issues/microsoft/vscode/bug.svg)](https://github.com/microsoft/vscode/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3Abug)
-[![Gitter](https://img.shields.io/badge/chat-on%20gitter-yellow.svg)](https://gitter.im/Microsoft/vscode)
+Joke Studio is a comedic writing environment that repurposes the Code&nbsp;– OSS project. Instead of working on files and applications, you craft and polish jokes for stand‑up comedy. Key features include:
+
+- Dedicated areas for work‑in‑progress jokes and polished material
+- Internal rating tools to track your best content
+- AI‑powered suggestions in the right sidebar for punchline revisions or new ideas
+- Categorization, filtering, and search to keep your notebook organized
 
 ## The Repository
 
-This repository ("`Code - OSS`") is where we (Microsoft) develop the [Visual Studio Code](https://code.visualstudio.com) product together with the community. Not only do we work on code and issues here, we also publish our [roadmap](https://github.com/microsoft/vscode/wiki/Roadmap), [monthly iteration plans](https://github.com/microsoft/vscode/wiki/Iteration-Plans), and our [endgame plans](https://github.com/microsoft/vscode/wiki/Running-the-Endgame). This source code is available to everyone under the standard [MIT license](https://github.com/microsoft/vscode/blob/main/LICENSE.txt).
+This repository ("`Joke - OSS`") is where we develop the Joke Studio application together with the community. It is based on the [Code&nbsp;– OSS](https://github.com/microsoft/vscode) project and is released under the [MIT license](https://github.com/microsoft/vscode/blob/main/LICENSE.txt). Contributions are welcome via issues and pull requests.
 
-## Visual Studio Code
+## Joke Studio
 
-<p align="center">
-  <img alt="VS Code in action" src="https://user-images.githubusercontent.com/35271042/118224532-3842c400-b438-11eb-923d-a5f66fa6785a.png">
-</p>
-
-[Visual Studio Code](https://code.visualstudio.com) is a distribution of the `Code - OSS` repository with Microsoft-specific customizations released under a traditional [Microsoft product license](https://code.visualstudio.com/License/).
-
-[Visual Studio Code](https://code.visualstudio.com) combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle. It provides comprehensive code editing, navigation, and understanding support along with lightweight debugging, a rich extensibility model, and lightweight integration with existing tools.
-
-Visual Studio Code is updated monthly with new features and bug fixes. You can download it for Windows, macOS, and Linux on [Visual Studio Code's website](https://code.visualstudio.com/Download). To get the latest releases every day, install the [Insiders build](https://code.visualstudio.com/insiders).
+Joke Studio builds on the open‑source foundations of Visual Studio Code and adapts the editor for comedy writing. You'll find the familiar editing experience along with specialized tools described above. We release updates regularly as new features and fixes become available.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- rename project to "Joke Studio" and describe new goals
- add bullet list of features
- mention the repository uses Code-OSS as a base
- shorten old Visual Studio Code section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e04f2513483299c1df8f923f27704