### PR TITLE
Replace VS Code references with penguin IDE

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -8,7 +8,7 @@ This repository includes configuration for a development container for working w
 
 ## Quick start - local
 
-If you already have VS Code and Docker installed, you can click the badge above or [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/vscode) to get started. Clicking these links will cause VS Code to automatically install the Dev Containers extension if needed, clone the source code into a container volume, and spin up a dev container for use.
+If you already have Joke Studio and Docker installed, you can click the badge above or [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/vscode) to get started. Clicking these links will cause Joke Studio to automatically install the Dev Containers extension if needed, clone the source code into a container volume, and spin up a dev container for use.
 
 1. Install Docker Desktop or Docker for Linux on your local machine. (See [docs](https://aka.ms/vscode-remote/containers/getting-started) for additional details.)
 
@@ -16,11 +16,11 @@ If you already have VS Code and Docker installed, you can click the badge above 
 
    > **Note:** The [Resource Monitor](https://marketplace.visualstudio.com/items?itemName=mutantdino.resourcemonitor) extension is included in the container so you can keep an eye on CPU/Memory in the status bar.
 
-3. Install [Visual Studio Code Stable](https://code.visualstudio.com/) or [Insiders](https://code.visualstudio.com/insiders/) and the [Dev Containers](https://aka.ms/vscode-remote/download/containers) extension.
+3. Install [the penguin-themed Joke Studio IDE Stable](https://code.visualstudio.com/) or [Insiders](https://code.visualstudio.com/insiders/) and the [Dev Containers](https://aka.ms/vscode-remote/download/containers) extension.
 
    ![Image of Dev Containers extension](https://microsoft.github.io/vscode-remote-release/images/dev-containers-extn.png)
 
-   > **Note:** The Dev Containers extension requires the Visual Studio Code distribution of Code - OSS. See the [FAQ](https://aka.ms/vscode-remote/faq/license) for details.
+   > **Note:** The Dev Containers extension requires the penguin-themed Joke Studio IDE distribution of Code - OSS. See the [FAQ](https://aka.ms/vscode-remote/faq/license) for details.
 
 4. Press <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd> and select **Dev Containers: Clone Repository in Container Volume...**.
 
@@ -30,7 +30,7 @@ If you already have VS Code and Docker installed, you can click the badge above 
 
 6. After the container is running:
     1. If you have the `DISPLAY` or `WAYLAND_DISPLAY` environment variables set locally (or in WSL on Windows), desktop apps in the container will be shown in local windows.
-    2. If these are not set, open a web browser and go to [http://localhost:6080](http://localhost:6080), or use a [VNC Viewer][def] to connect to `localhost:5901` and enter `vscode` as the password. Anything you start in VS Code, or the integrated terminal, will appear here.
+    2. If these are not set, open a web browser and go to [http://localhost:6080](http://localhost:6080), or use a [VNC Viewer][def] to connect to `localhost:5901` and enter `vscode` as the password. Anything you start in Joke Studio, or the integrated terminal, will appear here.
 
 Next: **[Try it out!](#try-it)**
 
@@ -48,19 +48,19 @@ Next: **[Try it out!](#try-it)**
 
 4. In the new tab, you should see noVNC. Click **Connect** and enter `vscode` as the password.
 
-Anything you start in VS Code, or the integrated terminal, will appear here.
+Anything you start in Joke Studio, or the integrated terminal, will appear here.
 
 Next: **[Try it out!](#try-it)**
 
-### Using VS Code with GitHub Codespaces
+### Using Joke Studio with GitHub Codespaces
 
-You may see improved VNC responsiveness when accessing a codespace from VS Code client since you can use a [VNC Viewer][def]. Here's how to do it.
+You may see improved VNC responsiveness when accessing a codespace from Joke Studio client since you can use a [VNC Viewer][def]. Here's how to do it.
 
-1. Install [Visual Studio Code Stable](https://code.visualstudio.com/) or [Insiders](https://code.visualstudio.com/insiders/) and the [GitHub Codespaces extension](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces).
+1. Install [the penguin-themed Joke Studio IDE Stable](https://code.visualstudio.com/) or [Insiders](https://code.visualstudio.com/insiders/) and the [GitHub Codespaces extension](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces).
 
-    > **Note:** The GitHub Codespaces extension requires the Visual Studio Code distribution of Code - OSS.
+    > **Note:** The GitHub Codespaces extension requires the penguin-themed Joke Studio IDE distribution of Code - OSS.
 
-2. After the VS Code is up and running, press <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd>, choose **Codespaces: Create New Codespace**, and use the following settings:
+2. After the Joke Studio is up and running, press <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd>, choose **Codespaces: Create New Codespace**, and use the following settings:
 
 - `microsoft/vscode` for the repository.
 - Select any branch (e.g. **main**) - you can select a different one later.
@@ -70,7 +70,7 @@ You may see improved VNC responsiveness when accessing a codespace from VS Code 
 
     > **Tip:** You may also need change your VNC client's **Picture Quality** setting to **High** to get a full color desktop.
 
-4. Anything you start in VS Code, or the integrated terminal, will appear here.
+4. Anything you start in Joke Studio, or the integrated terminal, will appear here.
 
 Next: **[Try it out!](#try-it)**
 
@@ -82,7 +82,7 @@ This container uses the [Fluxbox](http://fluxbox.org/) window manager to keep th
 
 To start working with Code - OSS, follow these steps:
 
-1. In your local VS Code client, open a terminal (<kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>\`</kbd>) and type the following commands:
+1. In your local Joke Studio client, open a terminal (<kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>\`</kbd>) and type the following commands:
 
    ```bash
    npm i
@@ -97,9 +97,9 @@ Next, let's try debugging.
 
 1. Shut down Code - OSS by clicking the box in the upper right corner of the Code - OSS window through your browser or VNC viewer.
 
-2. Go to your local VS Code client, and use the **Run / Debug** view to launch the **VS Code** configuration. (Typically the default, so you can likely just press <kbd>F5</kbd>).
+2. Go to your local Joke Studio client, and use the **Run / Debug** view to launch the **Joke Studio** configuration. (Typically the default, so you can likely just press <kbd>F5</kbd>).
 
-   > **Note:** If launching times out, you can increase the value of `timeout` in the "VS Code", "Attach Main Process", "Attach Extension Host", and "Attach to Shared Process" configurations in [launch.json](../.vscode/launch.json). However, running `./scripts/code.sh` first will set up Electron which will usually solve timeout issues.
+   > **Note:** If launching times out, you can increase the value of `timeout` in the "Joke Studio", "Attach Main Process", "Attach Extension Host", and "Attach to Shared Process" configurations in [launch.json](../.vscode/launch.json). However, running `./scripts/code.sh` first will set up Electron which will usually solve timeout issues.
 
 3. After a bit, Code - OSS will appear with the debugger attached!
 
@@ -107,6 +107,6 @@ Enjoy!
 
 ### Notes
 
-The container comes with VS Code Insiders installed. To run it from an Integrated Terminal use `VSCODE_IPC_HOOK_CLI= /usr/bin/code-insiders .`.
+The container comes with Joke Studio Insiders installed. To run it from an Integrated Terminal use `VSCODE_IPC_HOOK_CLI= /usr/bin/code-insiders .`.
 
 [def]: https://www.realvnc.com/en/connect/download/viewer/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to VS Code
+# Contributing to Penguin Joke Studio
 
-Welcome, and thank you for your interest in contributing to VS Code!
+Welcome, and thank you for your interest in contributing to the penguin-themed Joke Studio IDE!
 
 There are several ways in which you can contribute, beyond writing code. The goal of this document is to provide a high-level overview of how you can get involved.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository ("`Joke - OSS`") is where we develop the Joke Studio application
 
 ## Joke Studio
 
-Joke Studio builds on the open‑source foundations of Visual Studio Code and adapts the editor for comedy writing. You'll find the familiar editing experience along with specialized tools described above. We release updates regularly as new features and fixes become available.
+Joke Studio builds on the open‑source foundations of the penguin-themed Joke Studio IDE and adapts the editor for comedy writing. You'll find the familiar editing experience along with specialized tools described above. We release updates regularly as new features and fixes become available.
 
 ## Contributing
 
@@ -46,20 +46,20 @@ See our [wiki](https://github.com/microsoft/vscode/wiki/Feedback-Channels) for a
 
 ## Related Projects
 
-Many of the core components and extensions to VS Code live in their own repositories on GitHub. For example, the [node debug adapter](https://github.com/microsoft/vscode-node-debug) and the [mono debug adapter](https://github.com/microsoft/vscode-mono-debug) repositories are separate from each other. For a complete list, please visit the [Related Projects](https://github.com/microsoft/vscode/wiki/Related-Projects) page on our [wiki](https://github.com/microsoft/vscode/wiki).
+Many of the core components and extensions to the penguin-themed Joke Studio IDE live in their own repositories on GitHub. For example, the [node debug adapter](https://github.com/microsoft/vscode-node-debug) and the [mono debug adapter](https://github.com/microsoft/vscode-mono-debug) repositories are separate from each other. For a complete list, please visit the [Related Projects](https://github.com/microsoft/vscode/wiki/Related-Projects) page on our [wiki](https://github.com/microsoft/vscode/wiki).
 
 ## Bundled Extensions
 
-VS Code includes a set of built-in extensions located in the [extensions](extensions) folder, including grammars and snippets for many languages. Extensions that provide rich language support (code completion, Go to Definition) for a language have the suffix `language-features`. For example, the `json` extension provides coloring for `JSON` and the `json-language-features` extension provides rich language support for `JSON`.
+The penguin-themed Joke Studio IDE includes a set of built-in extensions located in the [extensions](extensions) folder, including grammars and snippets for many languages. Extensions that provide rich language support (code completion, Go to Definition) for a language have the suffix `language-features`. For example, the `json` extension provides coloring for `JSON` and the `json-language-features` extension provides rich language support for `JSON`.
 
 ## Development Container
 
-This repository includes a Visual Studio Code Dev Containers / GitHub Codespaces development container.
+This repository includes a penguin-themed Joke Studio Dev Containers / GitHub Codespaces development container.
 
 * For [Dev Containers](https://aka.ms/vscode-remote/download/containers), use the **Dev Containers: Clone Repository in Container Volume...** command which creates a Docker volume for better disk I/O on macOS and Windows.
-  * If you already have VS Code and Docker installed, you can also click [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/vscode) to get started. This will cause VS Code to automatically install the Dev Containers extension if needed, clone the source code into a container volume, and spin up a dev container for use.
+  * If you already have the Joke Studio client and Docker installed, you can also click [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/vscode) to get started. This will cause Joke Studio to automatically install the Dev Containers extension if needed, clone the source code into a container volume, and spin up a dev container for use.
 
-* For Codespaces, install the [GitHub Codespaces](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces) extension in VS Code, and use the **Codespaces: Create New Codespace** command.
+* For Codespaces, install the [GitHub Codespaces](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces) extension in Joke Studio, and use the **Codespaces: Create New Codespace** command.
 
 Docker / the Codespace should have at least **4 Cores and 6 GB of RAM (8 GB recommended)** to run full build. See the [development container README](.devcontainer/README.md) for more information.
 

--- a/scripts/generate-definitelytyped.sh
+++ b/scripts/generate-definitelytyped.sh
@@ -6,9 +6,9 @@ if [ $# -eq 0 ]; then
 	exit 1
 fi
 
-header="// Type definitions for Visual Studio Code ${1}
+header="// Type definitions for the penguin-themed Joke Studio IDE ${1}
 // Project: https://github.com/microsoft/vscode
-// Definitions by: Visual Studio Code Team, Microsoft <https://github.com/microsoft>
+// Definitions by: Joke Studio Team, Microsoft <https://github.com/microsoft>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /*---------------------------------------------------------------------------------------------
@@ -18,7 +18,7 @@ header="// Type definitions for Visual Studio Code ${1}
  *--------------------------------------------------------------------------------------------*/
 
 /**
- * Type Definition for Visual Studio Code ${1} Extension API
+ * Type Definition for the penguin-themed Joke Studio IDE ${1} Extension API
  * See https://code.visualstudio.com/api for more information
  */"
 

--- a/scripts/xterm-symlink.ps1
+++ b/scripts/xterm-symlink.ps1
@@ -26,7 +26,7 @@ if (Test-Path $XtermFolder -PathType Container)
 	yarn package -- --mode development
 	Set-Location -
 
-	Write-Host -ForegroundColor Green "`n:: Finished! To watch changes, open the VS Code terminal in the xterm.js repo and run:`n`n    yarn package -- --mode development --watch"
+        Write-Host -ForegroundColor Green "`n:: Finished! To watch changes, open the Joke Studio terminal in the xterm.js repo and run:`n`n    yarn package -- --mode development --watch"
 }
 else
 {


### PR DESCRIPTION
## Summary
- reference the penguin-themed **Joke Studio** IDE in docs
- update dev container docs with the new branding
- tweak script comments to mention Joke Studio

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e0945891083299858b6d881ed47db